### PR TITLE
Fix URL param in README and test

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ response.id
 
 # you can optionally pass in a callback url that we'll POST to when the
 # batch is complete.
-response = client.batch(emails, {'callback_url': 'https://emailable.com/'})
+response = client.batch(emails, {'url': 'https://emailable.com/'})
 ```
 
 #### Get the status / results of a batch

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -58,12 +58,12 @@ class TestClient(TestCase):
       ['evan@emailable.com', 'jarrett@emailable.com']
     )
     self.assertIsNotNone(response.id)
-  
+
   def test_batch_creation_with_params(self):
     with self.assertRaises(emailable.error.ClientError):
       self.client.batch(
         ['evan@emailable.com', 'jarrett@emailable.com'],
-        {'callback_url': 'test@example.org', 'simulate': 'generic_error'}
+        {'url': 'test@example.org', 'simulate': 'generic_error'}
       )
 
   def test_batch_status(self):


### PR DESCRIPTION
Updated the README and test to use `url` over the outdated `callback_url`